### PR TITLE
Upgrade to CDT 1.7 and add CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+*.wasm
+*.abi
+output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+project(eosmechanics VERSION 1.0 LANGUAGES CXX)
+find_package(eosio.cdt)
+
+add_subdirectory(contracts output/)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ This is a collection of EOS contracts and utilities in use by the [EOS Mechanics
 
 Please visit us on [Telegram](https://t.me/EOSMechanics) for any feedback or questions. 
 
+## Building
+This project uses [CMake](https://cmake.org/) as building tool. You need to know the location where your CDT is installed to be able to set the `CMAKE_TOOLCHAIN_FILE` variable when invoking the CMake build command. E.g.:
+```shell
+$ cmake -DCMAKE_TOOLCHAIN_FILE=/usr/local/opt/eosio.cdt/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake --build .
+$ make
+```
+This comand will generate the [Wasm](https://webassembly.org/) and the [ABI](https://developers.eos.io/welcome/latest/getting-started/smart-contract-development/understanding-ABI-files/#what-is-an-abi) to deploy into your network.
+
 ## Benchmarks
 The benchmarks below are EOS contracts which are set on the `eosmechanics` account on Mainnet, CryptoKylin Testnet, and Jungle Testnet. They are executed during each block producers' schedule, and the timings recorded on-chain using the standard `cpu_usage_us` transaction field. The data is [freely available](https://eosflare.io/account/eosmechanics) to view and analyze, and we encourage doing so to help identify issues and improve block producer performance.
 

--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_contract(eosmechanics eosmechanics eosmechanics.cpp)

--- a/contracts/eosmechanics.cpp
+++ b/contracts/eosmechanics.cpp
@@ -1,4 +1,4 @@
-#include <eosiolib/eosio.hpp>
+#include <eosio/eosio.hpp>
 //#include <eosiolib/print.hpp>
 #include <math.h>
 #pragma precision=log10l(ULLONG_MAX)/2


### PR DESCRIPTION
I wasn't able to fine tweak the generated file names using CMake.
This pull request generates `eosmechanics.wasm.abi` and  `eosmechanics.wasm.wasm` in the `output/` directory instead of the expected `eosmechanics.abi` and  `eosmechanics.wasm`.

I think this can be tackle in future improvements.